### PR TITLE
Httpd restart and disable selinux

### DIFF
--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -2,6 +2,8 @@
 
 # check functionality
 
+- meta: flush_handlers
+
 - set_fact:
     settings_url: "https://{{ ansible_default_ipv4.address }}/settings"
 


### PR DESCRIPTION
Httpd must be restarted after copy new config files and retrace
server need to have disable selinux to work
