### PR TITLE
Add WSGIProcessGroup

### DIFF
--- a/templates/retrace-server-httpd.conf.j2
+++ b/templates/retrace-server-httpd.conf.j2
@@ -31,6 +31,7 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
 </Directory>
 
 <LocationMatch "^/(manager(/.*)?|settings|create|stats|checkpackage|[0-9]+(/(log|backtrace|delete))?)?$">
+    WSGIProcessGroup retrace
     Options -Indexes -FollowSymLinks
     <IfModule mod_authz_core.c>
         # Apache 2.4


### PR DESCRIPTION
Without this included retrace-server is missing permisions to operate with:
 - /var/spool/retrace-server
 - /var/cache/retrace-server

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>