### PR TITLE
stop/disable firewalld

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,3 +8,6 @@
   template: src=retrace-server-httpd.conf.j2
             dest=/etc/httpd/conf.d/retrace-server-httpd.conf
   notify: restart httpd
+
+- name: stop/disable firewalld
+  service: name=firewalld state=stopped enabled=no


### PR DESCRIPTION
re: Fedora Infra mailing list - retrace/faf issues @ 6/26/17

This commit will stop/disable the firewalld service on the retrace servers as suggested by Kevin Fenzi.