### PR TITLE
Replace yum with generic OS package manager

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: erase retrace-server packages
-  yum: name=retrace-server state=absent
+  package: name=retrace-server state=absent
   when: rs_force_reinstall
 
 - name: install retrace-server package
-  yum : name=retrace-server state=installed
+  package: name=retrace-server state=installed


### PR DESCRIPTION
Automatically chooses package manager, ie. dnf for Fedora, yum for RHEL.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>