### PR TITLE
Allow to change path to repos in httpd config

### DIFF
--- a/templates/retrace-server-httpd.conf.j2
+++ b/templates/retrace-server-httpd.conf.j2
@@ -46,3 +46,8 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
 </LocationMatch>
 
 Alias /repos {{ rs_repo_dir }}
+<Directory "{{ rs_repo_dir }}">
+    Require all granted
+    Options Indexes FollowSymLinks
+    IndexOptions FancyIndexing
+</Directory>

--- a/templates/retrace-server-httpd.conf.j2
+++ b/templates/retrace-server-httpd.conf.j2
@@ -45,4 +45,4 @@ WSGIScriptAliasMatch ^/$ /usr/share/retrace-server/index.wsgi
     </IfModule>
 </LocationMatch>
 
-Alias /repos /var/cache/retrace-server
+Alias /repos {{ rs_repo_dir }}


### PR DESCRIPTION
The path to RepoDir in /etc/retrace-server.conf and /etc/httpd/conf.d/r-s.conf should be the same

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>