### PR TITLE
stop httpd before we are going to modify retrace user

### DIFF
--- a/tasks/podman.yml
+++ b/tasks/podman.yml
@@ -4,6 +4,11 @@
     name: podman
     state: present
 
+- name: Stop httpd to allow retrace user modification
+  service:
+    name: httpd
+    state: stopped
+
 - name: Set home directory for retrace user
   user:
     name: retrace
@@ -58,3 +63,8 @@
     command: usermod retrace --add-subgids "{{ rs_subgid_min }}-{{ rs_subgid_max }}"
 
   when: '"retrace" not in retrace_subgid.stdout'
+
+- name: Start httpd afterretrace user modification
+  service:
+    name: httpd
+    state: started


### PR DESCRIPTION
addressing:
TASK [abrt/retrace : Set home directory for retrace user] ***************************************************************
Friday 27 March 2020  20:06:21 +0000 (0:00:02.540)       0:05:51.330 **********
fatal: [retrace-stg.aws.fedoraproject.org]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/libexec/platform-python"}, "changed": false, "msg": "usermod: user retrace is currently used by process 13506\n", "name": "retrace", "rc": 8}