### PR TITLE
typo in variable name

### DIFF
--- a/tasks/podman.yml
+++ b/tasks/podman.yml
@@ -37,7 +37,7 @@
   - name: Set subuid for retrace user.
     command: usermod retrace --add-subuids "{{ rs_subuid_min }}-{{ rs_subuid_max }}"
 
-  when: '"retrace" not in retrace_subgid.stdout'
+  when: '"retrace" not in retrace_subuid.stdout'
 
 - name: Check if subgid is set for retrace user
   command: cat /etc/subgid


### PR DESCRIPTION
addressing:
TASK [abrt/retrace : Get last subuid entry] *****************************************************************************Monday 30 March 2020  07:15:43 +0000 (0:00:00.831)       0:05:45.873 **********
    fatal: [retrace-stg.aws.fedoraproject.org]: FAILED! => {"msg": "The conditional check '\"retrace\" not in retrace_subgid.stdout' failed. The error was: error while evaluating conditional (\"retrace\" not in retrace_subgid.stdout): Unable to look up a name or access an attribute in template string ({% if \"retrace\" not in retrace_subgid.stdout %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable\n\nThe error appears to be in '/srv/web/infra/ansible/roles/abrt/retrace/tasks/podman.yml': line 23, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- block:\n  - name: Get last subuid entry\n    ^ here\n"}