### PR TITLE
Update config for metrics + minor updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,9 @@ rs_keep_rawhide_latest: 3
 # Repo used to install chroot for vmcores
 rs_kernel_chroot_repo: http://dl.fedoraproject.org/pub/fedora/linux/releases/16/Everything/$ARCH/os/
 
+# Path to the kernel (vmcore) debugger
+rs_kernel_debugger_path: /usr/bin/crash
+
 # Koji directory structure can be used to search for kernel debuginfo
 rs_koji_root: /mnt/koji
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ rs_allow_interactive: false
 # Allow X-CoreFileDirectory header
 rs_allow_external_dir: false
 
+# Expose metrics for monitoring via Prometheus
+rs_allow_metrics: true
+
 # Allow to create tasks owned by task manager (security risk)
 rs_allow_task_manager: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,8 +128,9 @@ rs_use_faf_packages: false
 # Spool directory for FAF packages
 faf_spool_dir: /var/spool/faf
 
-# Run the retrace in a Mock chroot (default), or a Podman container
-# (mock|podman)
+# Run the retrace in a Mock chroot (default), a Podman container,
+# or on the native machine.
+# (mock|podman|native)
 rs_retrace_environment: podman
 
 # Whether to enable e-mail notifications

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,19 +1,18 @@
 ---
 galaxy_info:
   author: sorki
-  description: Deploy retrace-server
+  description: Retrace Server deployment
   license: BSD
-  min_ansible_version: 1.9
+  min_ansible_version: 2.8
   platforms:
    - name: EL
      versions:
       - 7
+      - 8
    - name: Fedora
      versions:
-      - 26
-      - 27
-      - 28
+      - 33
+      - 34
+      - 35
   galaxy_tags:
    - system
-#dependencies:
-#  - { role: httpd }

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,16 +3,19 @@
   template:
     src: etc-retrace-server.conf.j2
     dest: /etc/retrace-server/retrace-server.conf
+    mode: 0644
   notify: restart httpd
 
 - name: retrace-server http config
   template:
     src: retrace-server-httpd.conf.j2
     dest: /etc/httpd/conf.d/retrace-server-httpd.conf
+    mode: 0644
   notify: restart httpd
 
 - name: configure retrace-server hooks config
   template:
     src: etc-retrace-server-hooks.conf.j2
     dest: /etc/retrace-server/retrace-server-hooks.conf
+    mode: 0644
   notify: restart httpd

--- a/templates/etc-retrace-server.conf.j2
+++ b/templates/etc-retrace-server.conf.j2
@@ -176,6 +176,9 @@ BugzillaRegExes = {{ rs_bugzilla_regexes }}
 # Timeout (in seconds) for communication with any process
 ProcessCommunicateTimeout = {{ rs_process_communicate_timeout|int }}
 
+# Path to the kernel (vmcore) debugger
+KernelDebuggerPath = {{ rs_kernel_debugger_path }}
+
 [archhosts]
 {% for a in rs_archhosts %}
 {{ a.arch }} = {{ a.url|default('', true) }}

--- a/templates/etc-retrace-server.conf.j2
+++ b/templates/etc-retrace-server.conf.j2
@@ -135,8 +135,9 @@ UseFafPackages = {{ rs_use_faf_packages|int }}
 # Spool directory for FAF packages
 FafLinkDir = {{ faf_spool_dir }}
 
-# Run the retrace in a Mock chroot (default), or a Podman container
-# (mock|podman)
+# Run the retrace in a Mock chroot (default), a Podman container,
+# or on the native machine.
+# (mock|podman|native)
 RetraceEnvironment = {{ rs_retrace_environment }}
 
 # Whether to enable e-mail notifications

--- a/templates/etc-retrace-server.conf.j2
+++ b/templates/etc-retrace-server.conf.j2
@@ -21,6 +21,9 @@ AllowInteractive = {{ rs_allow_interactive|int }}
 # Allow X-CoreFileDirectory header
 AllowExternalDir = {{ rs_allow_external_dir|int }}
 
+# Expose metrics for monitoring via Prometheus
+AllowMetrics = {{ rs_allow_metrics|int }}
+
 # Allow to create tasks owned by task manager (security risk)
 AllowTaskManager = {{ rs_allow_task_manager|int }}
 


### PR DESCRIPTION
* Update role to accommodate for the Prometheus metrics feature (see abrt/retrace-server#419), enabled by default.
* Update for `KernelDebuggerPath` (see abrt/retrace-server#341).
* Update Ansible project metadata.
* Update some comments.
* Fix file permissions in `tasks/config.yml`.